### PR TITLE
bip39のmnemonic変換関数を追加

### DIFF
--- a/include/cfdcore/cfdcore_hdwallet.h
+++ b/include/cfdcore/cfdcore_hdwallet.h
@@ -10,9 +10,12 @@
 #include <string>
 #include <vector>
 
+#include "cfdcore/cfdcore_bytedata.h"
 #include "cfdcore/cfdcore_common.h"
 
 namespace cfdcore {
+
+using cfdcore::ByteData;
 
 /**
  * @brief HDWalletを表現するデータクラス
@@ -27,11 +30,64 @@ class CFD_CORE_EXPORT HDWallet {
   /**
    * @brief Mnemonic で利用できる Wordlist を取得する.
    * @param[in] language 取得するWordlistの言語
-   * @return Wordlist vector
+   * @return Wordlist配列
+   * @throws CfdException 非対応の言語が渡された場合
    */
-  static std::vector<std::string> GetMnemonicWordlist(std::string language);
+  static std::vector<std::string> GetMnemonicWordlist(
+      const std::string& language);
+
+  /**
+   * @brief mnemonic と passphrase から seed を生成する.
+   * @param[in] mnemonic                ニーモニック配列
+   * @param[in] passphrase              パスフレーズ
+   * @param[in] use_ideographic_space   全角スペースで区切るかのフラグ
+   * @return シード値バイトデータ
+   */
+  static ByteData ConvertMnemonicToSeed(
+      const std::vector<std::string>& mnemonic, const std::string& passphrase,
+      bool use_ideographic_space = false);
+
+  /**
+   * @brief Mnemonic で利用できる Wordlist を取得する.
+   * @param[in] entropy     Mnemonic生成のエントロピー値
+   * @param[in] language    Mnemonicの言語
+   * @return ニーモニック配列
+   * @throws CfdException 非対応の言語が渡された場合
+   */
+  static std::vector<std::string> ConvertEntropyToMnemonic(
+      const ByteData& entropy, const std::string& language);
+
+  /**
+   * @brief Mnemonic から Entropy へ変換する.
+   * @param[in] mnemonic  エントロピーを導出するニーモニック配列
+   * @param[in] language  ニーモニックの言語
+   * @return エントロピー値バイトデータ
+   * @throws CfdException If invalid language passed.
+   */
+  static ByteData ConvertMnemonicToEntropy(
+      const std::vector<std::string>& mnemonic, const std::string& language);
+
+  /**
+   * @brief Verify mnemonic is valid 
+   * @param[in] mnemonic                mnemonic vector to check valid
+   * @param[in] language                language to verify
+   * @param[in] use_ideographic_space   flag of using ideographic space
+   *     for mnemonic separator
+   * @retval true   mnemonic checksum is valid
+   * @retval true   mnemonic checksum is invalid
+   */
+  static bool CheckValidMnemonic(
+      const std::vector<std::string>& mnemonic, const std::string& language,
+      bool use_ideographic_space = false);
 
  private:
+  /**
+   * @brief Mnemonic でサポートしている言語であるかを判定する.
+   * @param[in] language  language used by mnemonic.
+   * @retval true   If language is supported.
+   * @retval false  If language is not supported.
+   */
+  static bool CheckSupportedLanguages(const std::string& language);
 };
 
 }  // namespace cfdcore

--- a/include/cfdcore/cfdcore_hdwallet.h
+++ b/include/cfdcore/cfdcore_hdwallet.h
@@ -28,6 +28,28 @@ class CFD_CORE_EXPORT HDWallet {
   HDWallet();
 
   /**
+   * @brief コンストラクタ
+   * @param[in] seed シード値
+   */
+  explicit HDWallet(const ByteData& seed);
+
+  /**
+   * @brief コンストラクタ
+   * @param[in] mnemonic                ニーモニック文字列配列
+   * @param[in] passphrase              パスフレーズ
+   * @param[in] use_ideographic_space   全角スペース利用フラグ(default: false)
+   */
+  HDWallet(
+      std::vector<std::string> mnemonic, std::string passphrase,
+      bool use_ideographic_space = false);
+
+  /**
+   * @brief seedを取得する
+   * @return seed値ByteData
+   */
+  ByteData GetSeed() const;
+
+  /**
    * @brief Mnemonic で利用できる Wordlist を取得する.
    * @param[in] language 取得するWordlistの言語
    * @return Wordlist配列
@@ -35,17 +57,6 @@ class CFD_CORE_EXPORT HDWallet {
    */
   static std::vector<std::string> GetMnemonicWordlist(
       const std::string& language);
-
-  /**
-   * @brief mnemonic と passphrase から seed を生成する.
-   * @param[in] mnemonic                ニーモニック配列
-   * @param[in] passphrase              パスフレーズ
-   * @param[in] use_ideographic_space   全角スペースで区切るかのフラグ
-   * @return シード値バイトデータ
-   */
-  static ByteData ConvertMnemonicToSeed(
-      const std::vector<std::string>& mnemonic, const std::string& passphrase,
-      bool use_ideographic_space = false);
 
   /**
    * @brief Mnemonic で利用できる Wordlist を取得する.
@@ -81,6 +92,8 @@ class CFD_CORE_EXPORT HDWallet {
       bool use_ideographic_space = false);
 
  private:
+  ByteData seed_;  //!< seed
+
   /**
    * @brief Mnemonic でサポートしている言語であるかを判定する.
    * @param[in] language  language used by mnemonic.
@@ -88,6 +101,17 @@ class CFD_CORE_EXPORT HDWallet {
    * @retval false  If language is not supported.
    */
   static bool CheckSupportedLanguages(const std::string& language);
+
+  /**
+   * @brief mnemonic と passphrase から seed を生成する.
+   * @param[in] mnemonic                ニーモニック配列
+   * @param[in] passphrase              パスフレーズ
+   * @param[in] use_ideographic_space   全角スペースで区切るかのフラグ
+   * @return シード値バイトデータ
+   */
+  static ByteData ConvertMnemonicToSeed(
+      const std::vector<std::string>& mnemonic, const std::string& passphrase,
+      bool use_ideographic_space = false);
 };
 
 }  // namespace cfdcore

--- a/include/cfdcore/cfdcore_util.h
+++ b/include/cfdcore/cfdcore_util.h
@@ -426,12 +426,21 @@ class CFD_CORE_EXPORT StringUtil {
   static std::string ByteToString(const std::vector<uint8_t> &bytes);
   /**
    * @brief 文字列を区切り文字で分割する.
-   * @param[in] str 分割対象文字列
-   * @param[in] delim 区切り文字
+   * @param[in] str     分割対象文字列
+   * @param[in] delim   区切り文字列
    * @return 区切り文字で区切られた文字列vector
    */
   static std::vector<std::string> Split(
-      const std::string &str, const char delim);
+      const std::string &str, const std::string &delim);
+  /**
+   * @brief 文字列配列を連結する.
+   * @param[in] str_list        文字列配列
+   * @param[in] separate_word   連結文字列
+   * @return 連結された文字列
+   */
+  static std::string Join(
+      const std::vector<std::string> &str_list,
+      const std::string &separate_word);
 
  private:
   StringUtil();

--- a/src/cfdcore_hdwallet.cpp
+++ b/src/cfdcore_hdwallet.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "cfdcore/cfdcore_bytedata.h"
 #include "cfdcore/cfdcore_exception.h"
 #include "cfdcore/cfdcore_hdwallet.h"
 #include "cfdcore/cfdcore_logger.h"
@@ -16,6 +17,26 @@
 namespace cfdcore {
 
 using logger::warn;
+
+/// empty seed string (64byte)
+static const std::string kEmptySeedStr = "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";  // NOLINT
+
+HDWallet::HDWallet() : seed_(ByteData(kEmptySeedStr)) {
+  // do nothing
+}
+
+HDWallet::HDWallet(const ByteData& seed) : seed_(seed) {
+  // do nothing
+}
+
+HDWallet::HDWallet(
+    std::vector<std::string> mnemonic, std::string passphrase,
+    bool use_ideographic_space)
+    : seed_(ByteData(kEmptySeedStr)) {
+  seed_ = ConvertMnemonicToSeed(mnemonic, passphrase, use_ideographic_space);
+}
+
+ByteData HDWallet::GetSeed() const { return seed_; }
 
 std::vector<std::string> HDWallet::GetMnemonicWordlist(
     const std::string& language) {
@@ -28,13 +49,6 @@ std::vector<std::string> HDWallet::GetMnemonicWordlist(
   }
 
   return WallyUtil::GetMnemonicWordlist(language);
-}
-
-ByteData HDWallet::ConvertMnemonicToSeed(
-    const std::vector<std::string>& mnemonic, const std::string& passphrase,
-    bool use_ideographic_space) {
-  return WallyUtil::ConvertMnemonicToSeed(
-      mnemonic, passphrase, use_ideographic_space);
 }
 
 std::vector<std::string> HDWallet::ConvertEntropyToMnemonic(
@@ -82,6 +96,13 @@ bool HDWallet::CheckSupportedLanguages(const std::string& language) {
   std::vector<std::string> slangs = WallyUtil::GetSupportedMnemonicLanguages();
   return (
       std::find(slangs.cbegin(), slangs.cend(), language) != slangs.cend());
+}
+
+ByteData HDWallet::ConvertMnemonicToSeed(
+    const std::vector<std::string>& mnemonic, const std::string& passphrase,
+    bool use_ideographic_space) {
+  return WallyUtil::ConvertMnemonicToSeed(
+      mnemonic, passphrase, use_ideographic_space);
 }
 
 }  // namespace cfdcore

--- a/src/cfdcore_hdwallet.cpp
+++ b/src/cfdcore_hdwallet.cpp
@@ -17,8 +17,71 @@ namespace cfdcore {
 
 using logger::warn;
 
-std::vector<std::string> HDWallet::GetMnemonicWordlist(std::string language) {
+std::vector<std::string> HDWallet::GetMnemonicWordlist(
+    const std::string& language) {
+  if (!CheckSupportedLanguages(language)) {
+    warn(
+        CFD_LOG_SOURCE, "Not support language passed. language=[{}]",
+        language);
+    throw CfdException(
+        CfdError::kCfdIllegalArgumentError, "Not support language passed.");
+  }
+
   return WallyUtil::GetMnemonicWordlist(language);
+}
+
+ByteData HDWallet::ConvertMnemonicToSeed(
+    const std::vector<std::string>& mnemonic, const std::string& passphrase,
+    bool use_ideographic_space) {
+  return WallyUtil::ConvertMnemonicToSeed(
+      mnemonic, passphrase, use_ideographic_space);
+}
+
+std::vector<std::string> HDWallet::ConvertEntropyToMnemonic(
+    const ByteData& entropy, const std::string& language) {
+  if (!CheckSupportedLanguages(language)) {
+    warn(
+        CFD_LOG_SOURCE, "Not support language passed. language=[{}]",
+        language);
+    throw CfdException(
+        CfdError::kCfdIllegalArgumentError, "Not support language passed.");
+  }
+
+  return WallyUtil::ConvertEntropyToMnemonic(entropy, language);
+}
+
+ByteData HDWallet::ConvertMnemonicToEntropy(
+    const std::vector<std::string>& mnemonic, const std::string& language) {
+  if (!CheckSupportedLanguages(language)) {
+    warn(
+        CFD_LOG_SOURCE, "Not support language passed. language=[{}]",
+        language);
+    throw CfdException(
+        CfdError::kCfdIllegalArgumentError, "Not support language passed.");
+  }
+
+  return WallyUtil::ConvertMnemonicToEntropy(mnemonic, language);
+}
+
+bool HDWallet::CheckValidMnemonic(
+    const std::vector<std::string>& mnemonic, const std::string& language,
+    bool use_ideographic_space) {
+  if (!CheckSupportedLanguages(language)) {
+    warn(
+        CFD_LOG_SOURCE, "Not support language passed. language=[{}]",
+        language);
+    throw CfdException(
+        CfdError::kCfdIllegalArgumentError, "Not support language passed.");
+  }
+
+  return WallyUtil::CheckValidMnemonic(
+      mnemonic, language, use_ideographic_space);
+}
+
+bool HDWallet::CheckSupportedLanguages(const std::string& language) {
+  std::vector<std::string> slangs = WallyUtil::GetSupportedMnemonicLanguages();
+  return (
+      std::find(slangs.cbegin(), slangs.cend(), language) != slangs.cend());
 }
 
 }  // namespace cfdcore

--- a/src/cfdcore_util.cpp
+++ b/src/cfdcore_util.cpp
@@ -5,6 +5,7 @@
  * @brief Utility関連クラス定義
  */
 
+#include <iterator>
 #include <random>
 #include <set>
 #include <sstream>
@@ -737,15 +738,37 @@ std::string StringUtil::ByteToString(const std::vector<uint8_t> &bytes) {
 }
 
 std::vector<std::string> StringUtil::Split(
-    const std::string &str, const char delim) {
+    const std::string &str, const std::string &delim) {
   std::vector<std::string> results;
 
-  std::stringstream ss(str);
+  size_t pos = 0, prev = 0;
   std::string item;
-  while (std::getline(ss, item, delim)) {
+  while ((pos = str.find(delim, prev)) != std::string::npos) {
+    item = str.substr(prev, pos - prev);
     results.push_back(item);
+    prev = pos + std::char_traits<char>::length(delim.c_str());
   }
+  item = str.substr(prev);
+  results.push_back(item);
+
   return results;
+}
+
+std::string StringUtil::Join(
+    const std::vector<std::string> &str_list,
+    const std::string &separate_word) {
+  std::stringstream ss;
+  std::copy(
+      str_list.begin(), str_list.end(),
+      std::ostream_iterator<std::string>(ss, separate_word.c_str()));
+  std::string result = ss.str();
+
+  if (result.size() < std::char_traits<char>::length(separate_word.c_str()))
+    return result;
+
+  result.erase(
+      result.size() - std::char_traits<char>::length(separate_word.c_str()));
+  return result;
 }
 
 }  // namespace cfdcore

--- a/src/cfdcore_wally_util.h
+++ b/src/cfdcore_wally_util.h
@@ -117,12 +117,69 @@ class WallyUtil {
 
   /**
    * @brief Mnemonic で利用できる Wordlist を取得する.
-   * @param[in] language  language to use.
+   * @param[in] language    language to use.
    * @return wordlist to use mnemonic which supported by bip39.
-   * @throws CfdException If invalid language passed.
+   * @throws CfdException   If invalid argument passed.
    */
   static std::vector<std::string> GetMnemonicWordlist(
       const std::string& language);
+
+  /**
+   * @brief mnemonic と passphrase から seed を生成する.
+   * @details This function doesn't check mnemonic words strictly.
+   *     If you need to check mnemonic is valid, may use CheckValidMnemonic.
+   * @param[in] mnemonic    mnemonic words list.
+   * @param[in] passphrase  passphrase used as a solt.
+   * @param[in] use_ideographic_space   flag of using ideographic space
+   *     for mnemonic separator
+   * @return binary seed to use hdwallet.
+   * @throws CfdException   If invalid argument passed.
+   */
+  static ByteData ConvertMnemonicToSeed(
+      const std::vector<std::string>& mnemonic, const std::string& passphrase,
+      bool use_ideographic_space = false);
+
+  /**
+   * @brief Entropy から Mnemonic を生成する.
+   * @param[in] entropy     entropy to generate mnemonic.
+   * @param[in] language    language to use mnemonic.
+   * @return mnemonic which is generated from entropy.
+   * @throws CfdException   If invalid argument passed.
+   */
+  static std::vector<std::string> ConvertEntropyToMnemonic(
+      const ByteData& entropy, const std::string& language);
+
+  /**
+   * @brief Mnemonic から Entropy へ変換する.
+   * @param[in] mnemonic    mnemonic to derive entropy.
+   * @param[in] language    language used by mnemonic.
+   * @param[in] use_ideographic_space   flag of using ideographic space
+   *     for mnemonic separator
+   * @return binary entropy.
+   * @throws CfdException   If invalid argument passed.
+   */
+  static ByteData ConvertMnemonicToEntropy(
+      const std::vector<std::string>& mnemonic, const std::string& language,
+      bool use_ideographic_space = false);
+
+  /**
+   * @brief Mnemonic でサポートしている言語を取得する.
+   * @return supported language vector.
+   */
+  static std::vector<std::string> GetSupportedMnemonicLanguages();
+
+  /**
+   * @brief Verify mnemonic is valid 
+   * @param[in] mnemonic                mnemonic vector to check valid
+   * @param[in] language                language to verify
+   * @param[in] use_ideographic_space   flag of using ideographic space
+   *     for mnemonic separator
+   * @retval true   mnemonic checksum is valid
+   * @retval true   mnemonic checksum is invalid
+   */
+  static bool CheckValidMnemonic(
+      const std::vector<std::string>& mnemonic, const std::string& language,
+      bool use_ideographic_space = false);
 
  private:
   /**
@@ -131,17 +188,11 @@ class WallyUtil {
   WallyUtil();
 
   /**
-   * @brief Mnemonic でサポートしている言語を取得する.
-   * @return languages to get wordlist by bip39.
-   */
-  static std::vector<std::string> GetSupportedMnemonicLanguages();
-
-  /**
    * @brief Get the 'index'th word from passed BIP39 wordlist.
    * @param[in] wardlist    the wordlist to get the word from.
    * @param[in] index       target index number of wordlist.
    * @return string of the word from wordlist.
-   * @throws CfdException If invalid arguments passed.
+   * @throws CfdException   If invalid arguments passed.
    */
   static std::string GetMnemonicWord(
       const words* wardlist, const size_t index);

--- a/test/test_hdwallet.cpp
+++ b/test/test_hdwallet.cpp
@@ -179,29 +179,41 @@ TEST(HDWallet, ConvertTest) {
   std::vector<std::string> actual_mnemonic;
   ByteData actual_seed;
   bool actual_is_valid;
+  HDWallet hd_wallet;
+
+  HDWallet copy_wallet;
+  ByteData copy_seed;
   for (Bip39TestVector test_vector : bip39_test_vectors) {
+    EXPECT_NO_THROW(hd_wallet = HDWallet(test_vector.mnemonic, test_passphrase));
+    EXPECT_NO_THROW(actual_seed = hd_wallet.GetSeed());
     EXPECT_NO_THROW(actual_entropy = HDWallet::ConvertMnemonicToEntropy(test_vector.mnemonic, language));
     EXPECT_NO_THROW(actual_mnemonic = HDWallet::ConvertEntropyToMnemonic(test_vector.entropy, language));
-    EXPECT_NO_THROW(actual_seed = HDWallet::ConvertMnemonicToSeed(test_vector.mnemonic, test_passphrase));
     EXPECT_NO_THROW(actual_is_valid = HDWallet::CheckValidMnemonic(test_vector.mnemonic, language));
     EXPECT_TRUE(actual_entropy.Equals(test_vector.entropy));
     EXPECT_EQ(actual_mnemonic, test_vector.mnemonic);
     EXPECT_TRUE(actual_seed.Equals(test_vector.seed));
     EXPECT_TRUE(actual_is_valid);
+
+    copy_wallet = HDWallet(actual_seed);
+    EXPECT_NO_THROW(copy_seed = copy_wallet.GetSeed());
+    EXPECT_TRUE(copy_seed.Equals(test_vector.seed));
   }
 }
 
 const std::vector<std::string> empty_mnemonic = {};
 const std::vector<std::string> invalid_words_mnemonic = {"aa","aa","aa","aa","aa","aa","aa","aa","aa","aa","aa","abort"};
 
-TEST(HDWallet, ConvertMnemonicToSeedAllowAnyTest) {
+TEST(HDWallet, AllowAnyMnemonicTest) {
   try {
+    HDWallet hd_wallet;
     ByteData actual_seed;
     // check empty mnemonic
-    EXPECT_NO_THROW(actual_seed = HDWallet::ConvertMnemonicToSeed(empty_mnemonic, test_passphrase));
+    EXPECT_NO_THROW(hd_wallet = HDWallet(empty_mnemonic, test_passphrase));
+    EXPECT_NO_THROW(actual_seed = hd_wallet.GetSeed());
 
     // check invalid mnemonic
-    EXPECT_NO_THROW(actual_seed = HDWallet::ConvertMnemonicToSeed(invalid_words_mnemonic, test_passphrase));
+    EXPECT_NO_THROW(hd_wallet = HDWallet(invalid_words_mnemonic, test_passphrase));
+    EXPECT_NO_THROW(actual_seed = hd_wallet.GetSeed());
   } catch (...) {
     // force to fail test
     EXPECT_TRUE(false);

--- a/test/test_hdwallet.cpp
+++ b/test/test_hdwallet.cpp
@@ -2,6 +2,7 @@
 #include <map>
 #include <vector>
 
+#include "cfdcore/cfdcore_bytedata.h"
 #include "cfdcore/cfdcore_exception.h"
 #include "cfdcore/cfdcore_hdwallet.h"
 
@@ -9,10 +10,12 @@
 
 // TEST(test_suite_name, test_name)
 
-using cfdcore::HDWallet;
+using cfdcore::ByteData;
 using cfdcore::CfdException;
+using cfdcore::HDWallet;
 
 TEST(HDWallet, GetMnemonicWordlistTest) {
+  // ref: https://github.com/bitcoin/bips/blob/master/bip-0039/english.txt
   std::vector<std::string> expect_en_words = {"abandon", "ability", "able", "about", "above", "absent", "absorb", "abstract", "absurd", "abuse", "access", "accident", "account", "accuse", "achieve", "acid", "acoustic", "acquire", "across", "act", "action", "actor", "actress", "actual", "adapt", "add", "addict", "address", "adjust", "admit", "adult", "advance", "advice", "aerobic", "affair", "afford", "afraid", "again", "age", "agent", "agree", "ahead", "aim", "air", "airport", "aisle", "alarm", "album", "alcohol", "alert", "alien", "all", "alley", "allow", "almost", "alone", "alpha", "already", "also", "alter", "always", "amateur", "amazing", "among", "amount", "amused", "analyst", "anchor", "ancient", "anger", "angle", "angry", "animal", "ankle", "announce", "annual", "another", "answer", "antenna", "antique", "anxiety", "any", "apart", "apology", "appear", "apple", "approve", "april", "arch", "arctic", "area", "arena", "argue", "arm", "armed", "armor", "army", "around", "arrange", "arrest", "arrive", "arrow", "art", "artefact", "artist", "artwork", "ask", "aspect", "assault", "asset", "assist", "assume", "asthma", "athlete", "atom", "attack", "attend", "attitude", "attract", "auction", "audit", "august", "aunt", "author", "auto", "autumn", "average", "avocado", "avoid", "awake", "aware", "away", "awesome", "awful", "awkward", "axis", "baby", "bachelor", "bacon", "badge", "bag", "balance", "balcony", "ball", "bamboo", "banana", "banner", "bar", "barely", "bargain", "barrel", "base", "basic", "basket", "battle", "beach", "bean", "beauty", "because", "become", "beef", "before", "begin", "behave", "behind", "believe", "below", "belt", "bench", "benefit", "best", "betray", "better", "between", "beyond", "bicycle", "bid", "bike", "bind", "biology", "bird", "birth", "bitter", "black", "blade", "blame", "blanket", "blast", "bleak", "bless", "blind", "blood", "blossom", "blouse", "blue", "blur", "blush", "board", "boat", "body", "boil", "bomb", "bone", "bonus", "book", "boost", "border", "boring", "borrow", "boss", "bottom", "bounce", "box", "boy", "bracket", "brain", "brand", "brass", "brave", "bread", "breeze", "brick", "bridge", "brief", "bright", "bring", "brisk", "broccoli", "broken", "bronze", "broom", "brother", "brown", "brush", "bubble", "buddy", "budget", "buffalo", "build", "bulb", "bulk", "bullet", "bundle", "bunker", "burden", "burger", "burst", "bus", "business", "busy", "butter", "buyer", "buzz", "cabbage", "cabin", "cable", "cactus", "cage", "cake", "call", "calm", "camera", "camp", "can", "canal", "cancel", "candy", "cannon", "canoe", "canvas", "canyon", "capable", "capital", "captain", "car", "carbon", "card", "cargo", "carpet", "carry", "cart", "case", "cash", "casino", "castle", "casual", "cat", "catalog", "catch", "category", "cattle", "caught", "cause", "caution", "cave", "ceiling", "celery", "cement", "census", "century", "cereal", "certain", "chair", "chalk", "champion", "change", "chaos", "chapter", "charge", "chase", "chat", "cheap", "check", "cheese", "chef", "cherry", "chest", "chicken", "chief", "child", "chimney", "choice", "choose", "chronic", "chuckle", "chunk", "churn", "cigar", "cinnamon", "circle", "citizen", "city", "civil", "claim", "clap", "clarify", "claw", "clay", "clean", "clerk", "clever", "click", "client", "cliff", "climb", "clinic", "clip", "clock", "clog", "close", "cloth", "cloud", "clown", "club", "clump", "cluster", "clutch", "coach", "coast", "coconut", "code", "coffee", "coil", "coin", "collect", "color", "column", "combine", "come", "comfort", "comic", "common", "company", "concert", "conduct", "confirm", "congress", "connect", "consider", "control", "convince", "cook", "cool", "copper", "copy", "coral", "core", "corn", "correct", "cost", "cotton", "couch", "country", "couple", "course", "cousin", "cover", "coyote", "crack", "cradle", "craft", "cram", "crane", "crash", "crater", "crawl", "crazy", "cream", "credit", "creek", "crew", "cricket", "crime", "crisp", "critic", "crop", "cross", "crouch", "crowd", "crucial", "cruel", "cruise", "crumble", "crunch", "crush", "cry", "crystal", "cube", "culture", "cup", "cupboard", "curious", "current", "curtain", "curve", "cushion", "custom", "cute", "cycle", "dad", "damage", "damp", "dance", "danger", "daring", "dash", "daughter", "dawn", "day", "deal", "debate", "debris", "decade", "december", "decide", "decline", "decorate", "decrease", "deer", "defense", "define", "defy", "degree", "delay", "deliver", "demand", "demise", "denial", "dentist", "deny", "depart", "depend", "deposit", "depth", "deputy", "derive", "describe", "desert", "design", "desk", "despair", "destroy", "detail", "detect", "develop", "device", "devote", "diagram", "dial", "diamond", "diary", "dice", "diesel", "diet", "differ", "digital", "dignity", "dilemma", "dinner", "dinosaur", "direct", "dirt", "disagree", "discover", "disease", "dish", "dismiss", "disorder", "display", "distance", "divert", "divide", "divorce", "dizzy", "doctor", "document", "dog", "doll", "dolphin", "domain", "donate", "donkey", "donor", "door", "dose", "double", "dove", "draft", "dragon", "drama", "drastic", "draw", "dream", "dress", "drift", "drill", "drink", "drip", "drive", "drop", "drum", "dry", "duck", "dumb", "dune", "during", "dust", "dutch", "duty", "dwarf", "dynamic", "eager", "eagle", "early", "earn", "earth", "easily", "east", "easy", "echo", "ecology", "economy", "edge", "edit", "educate", "effort", "egg", "eight", "either", "elbow", "elder", "electric", "elegant", "element", "elephant", "elevator", "elite", "else", "embark", "embody", "embrace", "emerge", "emotion", "employ", "empower", "empty", "enable", "enact", "end", "endless", "endorse", "enemy", "energy", "enforce", "engage", "engine", "enhance", "enjoy", "enlist", "enough", "enrich", "enroll", "ensure", "enter", "entire", "entry", "envelope", "episode", "equal", "equip", "era", "erase", "erode", "erosion", "error", "erupt", "escape", "essay", "essence", "estate", "eternal", "ethics", "evidence", "evil", "evoke", "evolve", "exact", "example", "excess", "exchange", "excite", "exclude", "excuse", "execute", "exercise", "exhaust", "exhibit", "exile", "exist", "exit", "exotic", "expand", "expect", "expire", "explain", "expose", "express", "extend", "extra", "eye", "eyebrow", "fabric", "face", "faculty", "fade", "faint", "faith", "fall", "false", "fame", "family", "famous", "fan", "fancy", "fantasy", "farm", "fashion", "fat", "fatal", "father", "fatigue", "fault", "favorite", "feature", "february", "federal", "fee", "feed", "feel", "female", "fence", "festival", "fetch", "fever", "few", "fiber", "fiction", "field", "figure", "file", "film", "filter", "final", "find", "fine", "finger", "finish", "fire", "firm", "first", "fiscal", "fish", "fit", "fitness", "fix", "flag", "flame", "flash", "flat", "flavor", "flee", "flight", "flip", "float", "flock", "floor", "flower", "fluid", "flush", "fly", "foam", "focus", "fog", "foil", "fold", "follow", "food", "foot", "force", "forest", "forget", "fork", "fortune", "forum", "forward", "fossil", "foster", "found", "fox", "fragile", "frame", "frequent", "fresh", "friend", "fringe", "frog", "front", "frost", "frown", "frozen", "fruit", "fuel", "fun", "funny", "furnace", "fury", "future", "gadget", "gain", "galaxy", "gallery", "game", "gap", "garage", "garbage", "garden", "garlic", "garment", "gas", "gasp", "gate", "gather", "gauge", "gaze", "general", "genius", "genre", "gentle", "genuine", "gesture", "ghost", "giant", "gift", "giggle", "ginger", "giraffe", "girl", "give", "glad", "glance", "glare", "glass", "glide", "glimpse", "globe", "gloom", "glory", "glove", "glow", "glue", "goat", "goddess", "gold", "good", "goose", "gorilla", "gospel", "gossip", "govern", "gown", "grab", "grace", "grain", "grant", "grape", "grass", "gravity", "great", "green", "grid", "grief", "grit", "grocery", "group", "grow", "grunt", "guard", "guess", "guide", "guilt", "guitar", "gun", "gym", "habit", "hair", "half", "hammer", "hamster", "hand", "happy", "harbor", "hard", "harsh", "harvest", "hat", "have", "hawk", "hazard", "head", "health", "heart", "heavy", "hedgehog", "height", "hello", "helmet", "help", "hen", "hero", "hidden", "high", "hill", "hint", "hip", "hire", "history", "hobby", "hockey", "hold", "hole", "holiday", "hollow", "home", "honey", "hood", "hope", "horn", "horror", "horse", "hospital", "host", "hotel", "hour", "hover", "hub", "huge", "human", "humble", "humor", "hundred", "hungry", "hunt", "hurdle", "hurry", "hurt", "husband", "hybrid", "ice", "icon", "idea", "identify", "idle", "ignore", "ill", "illegal", "illness", "image", "imitate", "immense", "immune", "impact", "impose", "improve", "impulse", "inch", "include", "income", "increase", "index", "indicate", "indoor", "industry", "infant", "inflict", "inform", "inhale", "inherit", "initial", "inject", "injury", "inmate", "inner", "innocent", "input", "inquiry", "insane", "insect", "inside", "inspire", "install", "intact", "interest", "into", "invest", "invite", "involve", "iron", "island", "isolate", "issue", "item", "ivory", "jacket", "jaguar", "jar", "jazz", "jealous", "jeans", "jelly", "jewel", "job", "join", "joke", "journey", "joy", "judge", "juice", "jump", "jungle", "junior", "junk", "just", "kangaroo", "keen", "keep", "ketchup", "key", "kick", "kid", "kidney", "kind", "kingdom", "kiss", "kit", "kitchen", "kite", "kitten", "kiwi", "knee", "knife", "knock", "know", "lab", "label", "labor", "ladder", "lady", "lake", "lamp", "language", "laptop", "large", "later", "latin", "laugh", "laundry", "lava", "law", "lawn", "lawsuit", "layer", "lazy", "leader", "leaf", "learn", "leave", "lecture", "left", "leg", "legal", "legend", "leisure", "lemon", "lend", "length", "lens", "leopard", "lesson", "letter", "level", "liar", "liberty", "library", "license", "life", "lift", "light", "like", "limb", "limit", "link", "lion", "liquid", "list", "little", "live", "lizard", "load", "loan", "lobster", "local", "lock", "logic", "lonely", "long", "loop", "lottery", "loud", "lounge", "love", "loyal", "lucky", "luggage", "lumber", "lunar", "lunch", "luxury", "lyrics", "machine", "mad", "magic", "magnet", "maid", "mail", "main", "major", "make", "mammal", "man", "manage", "mandate", "mango", "mansion", "manual", "maple", "marble", "march", "margin", "marine", "market", "marriage", "mask", "mass", "master", "match", "material", "math", "matrix", "matter", "maximum", "maze", "meadow", "mean", "measure", "meat", "mechanic", "medal", "media", "melody", "melt", "member", "memory", "mention", "menu", "mercy", "merge", "merit", "merry", "mesh", "message", "metal", "method", "middle", "midnight", "milk", "million", "mimic", "mind", "minimum", "minor", "minute", "miracle", "mirror", "misery", "miss", "mistake", "mix", "mixed", "mixture", "mobile", "model", "modify", "mom", "moment", "monitor", "monkey", "monster", "month", "moon", "moral", "more", "morning", "mosquito", "mother", "motion", "motor", "mountain", "mouse", "move", "movie", "much", "muffin", "mule", "multiply", "muscle", "museum", "mushroom", "music", "must", "mutual", "myself", "mystery", "myth", "naive", "name", "napkin", "narrow", "nasty", "nation", "nature", "near", "neck", "need", "negative", "neglect", "neither", "nephew", "nerve", "nest", "net", "network", "neutral", "never", "news", "next", "nice", "night", "noble", "noise", "nominee", "noodle", "normal", "north", "nose", "notable", "note", "nothing", "notice", "novel", "now", "nuclear", "number", "nurse", "nut", "oak", "obey", "object", "oblige", "obscure", "observe", "obtain", "obvious", "occur", "ocean", "october", "odor", "off", "offer", "office", "often", "oil", "okay", "old", "olive", "olympic", "omit", "once", "one", "onion", "online", "only", "open", "opera", "opinion", "oppose", "option", "orange", "orbit", "orchard", "order", "ordinary", "organ", "orient", "original", "orphan", "ostrich", "other", "outdoor", "outer", "output", "outside", "oval", "oven", "over", "own", "owner", "oxygen", "oyster", "ozone", "pact", "paddle", "page", "pair", "palace", "palm", "panda", "panel", "panic", "panther", "paper", "parade", "parent", "park", "parrot", "party", "pass", "patch", "path", "patient", "patrol", "pattern", "pause", "pave", "payment", "peace", "peanut", "pear", "peasant", "pelican", "pen", "penalty", "pencil", "people", "pepper", "perfect", "permit", "person", "pet", "phone", "photo", "phrase", "physical", "piano", "picnic", "picture", "piece", "pig", "pigeon", "pill", "pilot", "pink", "pioneer", "pipe", "pistol", "pitch", "pizza", "place", "planet", "plastic", "plate", "play", "please", "pledge", "pluck", "plug", "plunge", "poem", "poet", "point", "polar", "pole", "police", "pond", "pony", "pool", "popular", "portion", "position", "possible", "post", "potato", "pottery", "poverty", "powder", "power", "practice", "praise", "predict", "prefer", "prepare", "present", "pretty", "prevent", "price", "pride", "primary", "print", "priority", "prison", "private", "prize", "problem", "process", "produce", "profit", "program", "project", "promote", "proof", "property", "prosper", "protect", "proud", "provide", "public", "pudding", "pull", "pulp", "pulse", "pumpkin", "punch", "pupil", "puppy", "purchase", "purity", "purpose", "purse", "push", "put", "puzzle", "pyramid", "quality", "quantum", "quarter", "question", "quick", "quit", "quiz", "quote", "rabbit", "raccoon", "race", "rack", "radar", "radio", "rail", "rain", "raise", "rally", "ramp", "ranch", "random", "range", "rapid", "rare", "rate", "rather", "raven", "raw", "razor", "ready", "real", "reason", "rebel", "rebuild", "recall", "receive", "recipe", "record", "recycle", "reduce", "reflect", "reform", "refuse", "region", "regret", "regular", "reject", "relax", "release", "relief", "rely", "remain", "remember", "remind", "remove", "render", "renew", "rent", "reopen", "repair", "repeat", "replace", "report", "require", "rescue", "resemble", "resist", "resource", "response", "result", "retire", "retreat", "return", "reunion", "reveal", "review", "reward", "rhythm", "rib", "ribbon", "rice", "rich", "ride", "ridge", "rifle", "right", "rigid", "ring", "riot", "ripple", "risk", "ritual", "rival", "river", "road", "roast", "robot", "robust", "rocket", "romance", "roof", "rookie", "room", "rose", "rotate", "rough", "round", "route", "royal", "rubber", "rude", "rug", "rule", "run", "runway", "rural", "sad", "saddle", "sadness", "safe", "sail", "salad", "salmon", "salon", "salt", "salute", "same", "sample", "sand", "satisfy", "satoshi", "sauce", "sausage", "save", "say", "scale", "scan", "scare", "scatter", "scene", "scheme", "school", "science", "scissors", "scorpion", "scout", "scrap", "screen", "script", "scrub", "sea", "search", "season", "seat", "second", "secret", "section", "security", "seed", "seek", "segment", "select", "sell", "seminar", "senior", "sense", "sentence", "series", "service", "session", "settle", "setup", "seven", "shadow", "shaft", "shallow", "share", "shed", "shell", "sheriff", "shield", "shift", "shine", "ship", "shiver", "shock", "shoe", "shoot", "shop", "short", "shoulder", "shove", "shrimp", "shrug", "shuffle", "shy", "sibling", "sick", "side", "siege", "sight", "sign", "silent", "silk", "silly", "silver", "similar", "simple", "since", "sing", "siren", "sister", "situate", "six", "size", "skate", "sketch", "ski", "skill", "skin", "skirt", "skull", "slab", "slam", "sleep", "slender", "slice", "slide", "slight", "slim", "slogan", "slot", "slow", "slush", "small", "smart", "smile", "smoke", "smooth", "snack", "snake", "snap", "sniff", "snow", "soap", "soccer", "social", "sock", "soda", "soft", "solar", "soldier", "solid", "solution", "solve", "someone", "song", "soon", "sorry", "sort", "soul", "sound", "soup", "source", "south", "space", "spare", "spatial", "spawn", "speak", "special", "speed", "spell", "spend", "sphere", "spice", "spider", "spike", "spin", "spirit", "split", "spoil", "sponsor", "spoon", "sport", "spot", "spray", "spread", "spring", "spy", "square", "squeeze", "squirrel", "stable", "stadium", "staff", "stage", "stairs", "stamp", "stand", "start", "state", "stay", "steak", "steel", "stem", "step", "stereo", "stick", "still", "sting", "stock", "stomach", "stone", "stool", "story", "stove", "strategy", "street", "strike", "strong", "struggle", "student", "stuff", "stumble", "style", "subject", "submit", "subway", "success", "such", "sudden", "suffer", "sugar", "suggest", "suit", "summer", "sun", "sunny", "sunset", "super", "supply", "supreme", "sure", "surface", "surge", "surprise", "surround", "survey", "suspect", "sustain", "swallow", "swamp", "swap", "swarm", "swear", "sweet", "swift", "swim", "swing", "switch", "sword", "symbol", "symptom", "syrup", "system", "table", "tackle", "tag", "tail", "talent", "talk", "tank", "tape", "target", "task", "taste", "tattoo", "taxi", "teach", "team", "tell", "ten", "tenant", "tennis", "tent", "term", "test", "text", "thank", "that", "theme", "then", "theory", "there", "they", "thing", "this", "thought", "three", "thrive", "throw", "thumb", "thunder", "ticket", "tide", "tiger", "tilt", "timber", "time", "tiny", "tip", "tired", "tissue", "title", "toast", "tobacco", "today", "toddler", "toe", "together", "toilet", "token", "tomato", "tomorrow", "tone", "tongue", "tonight", "tool", "tooth", "top", "topic", "topple", "torch", "tornado", "tortoise", "toss", "total", "tourist", "toward", "tower", "town", "toy", "track", "trade", "traffic", "tragic", "train", "transfer", "trap", "trash", "travel", "tray", "treat", "tree", "trend", "trial", "tribe", "trick", "trigger", "trim", "trip", "trophy", "trouble", "truck", "true", "truly", "trumpet", "trust", "truth", "try", "tube", "tuition", "tumble", "tuna", "tunnel", "turkey", "turn", "turtle", "twelve", "twenty", "twice", "twin", "twist", "two", "type", "typical", "ugly", "umbrella", "unable", "unaware", "uncle", "uncover", "under", "undo", "unfair", "unfold", "unhappy", "uniform", "unique", "unit", "universe", "unknown", "unlock", "until", "unusual", "unveil", "update", "upgrade", "uphold", "upon", "upper", "upset", "urban", "urge", "usage", "use", "used", "useful", "useless", "usual", "utility", "vacant", "vacuum", "vague", "valid", "valley", "valve", "van", "vanish", "vapor", "various", "vast", "vault", "vehicle", "velvet", "vendor", "venture", "venue", "verb", "verify", "version", "very", "vessel", "veteran", "viable", "vibrant", "vicious", "victory", "video", "view", "village", "vintage", "violin", "virtual", "virus", "visa", "visit", "visual", "vital", "vivid", "vocal", "voice", "void", "volcano", "volume", "vote", "voyage", "wage", "wagon", "wait", "walk", "wall", "walnut", "want", "warfare", "warm", "warrior", "wash", "wasp", "waste", "water", "wave", "way", "wealth", "weapon", "wear", "weasel", "weather", "web", "wedding", "weekend", "weird", "welcome", "west", "wet", "whale", "what", "wheat", "wheel", "when", "where", "whip", "whisper", "wide", "width", "wife", "wild", "will", "win", "window", "wine", "wing", "wink", "winner", "winter", "wire", "wisdom", "wise", "wish", "witness", "wolf", "woman", "wonder", "wood", "wool", "word", "work", "world", "worry", "worth", "wrap", "wreck", "wrestle", "wrist", "write", "wrong", "yard", "year", "yellow", "you", "young", "youth", "zebra", "zero", "zone", "zoo"};
 
   // check en
@@ -32,6 +35,245 @@ TEST(HDWallet, GetMnemonicWordlistErrorTest) {
     std::string language = "zz";
     std::vector<std::string> actual_wordlist;
     EXPECT_THROW(actual_wordlist = HDWallet::GetMnemonicWordlist(language), CfdException);
+  } catch (CfdException &e) {
+    EXPECT_STREQ(e.what(), "Not support language passed.");
+  } catch (...) {
+    // force to fail test
+    EXPECT_TRUE(false);
+  }
+}
+
+struct Bip39TestVector {
+  ByteData entropy;
+  std::vector<std::string> mnemonic;
+  ByteData seed;
+};
+
+const std::string test_passphrase = "TREZOR";
+const std::string language = "en";
+const std::vector<Bip39TestVector> bip39_test_vectors = {
+  {
+    ByteData("00000000000000000000000000000000"),
+    {"abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","about"},
+    ByteData("c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04")
+  },
+  {
+    ByteData("7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f"),
+    {"legal","winner","thank","year","wave","sausage","worth","useful","legal","winner","thank","yellow"},
+    ByteData("2e8905819b8723fe2c1d161860e5ee1830318dbf49a83bd451cfb8440c28bd6fa457fe1296106559a3c80937a1c1069be3a3a5bd381ee6260e8d9739fce1f607")
+  },
+  {
+    ByteData("80808080808080808080808080808080"),
+    {"letter","advice","cage","absurd","amount","doctor","acoustic","avoid","letter","advice","cage","above"},
+    ByteData("d71de856f81a8acc65e6fc851a38d4d7ec216fd0796d0a6827a3ad6ed5511a30fa280f12eb2e47ed2ac03b5c462a0358d18d69fe4f985ec81778c1b370b652a8")
+  },
+  {
+    ByteData("ffffffffffffffffffffffffffffffff"),
+    {"zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","wrong"},
+    ByteData("ac27495480225222079d7be181583751e86f571027b0497b5b5d11218e0a8a13332572917f0f8e5a589620c6f15b11c61dee327651a14c34e18231052e48c069")
+  },
+  {
+    ByteData("000000000000000000000000000000000000000000000000"),
+    {"abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","agent"},
+    ByteData("035895f2f481b1b0f01fcf8c289c794660b289981a78f8106447707fdd9666ca06da5a9a565181599b79f53b844d8a71dd9f439c52a3d7b3e8a79c906ac845fa")
+  },
+  {
+    ByteData("7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f"),
+    {"legal","winner","thank","year","wave","sausage","worth","useful","legal","winner","thank","year","wave","sausage","worth","useful","legal","will"},
+    ByteData("f2b94508732bcbacbcc020faefecfc89feafa6649a5491b8c952cede496c214a0c7b3c392d168748f2d4a612bada0753b52a1c7ac53c1e93abd5c6320b9e95dd")
+  },
+  {
+    ByteData("808080808080808080808080808080808080808080808080"),
+    {"letter","advice","cage","absurd","amount","doctor","acoustic","avoid","letter","advice","cage","absurd","amount","doctor","acoustic","avoid","letter","always"},
+    ByteData("107d7c02a5aa6f38c58083ff74f04c607c2d2c0ecc55501dadd72d025b751bc27fe913ffb796f841c49b1d33b610cf0e91d3aa239027f5e99fe4ce9e5088cd65")
+  },
+  {
+    ByteData("ffffffffffffffffffffffffffffffffffffffffffffffff"),
+    {"zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","when"},
+    ByteData("0cd6e5d827bb62eb8fc1e262254223817fd068a74b5b449cc2f667c3f1f985a76379b43348d952e2265b4cd129090758b3e3c2c49103b5051aac2eaeb890a528")
+  },
+  {
+    ByteData("0000000000000000000000000000000000000000000000000000000000000000"),
+    {"abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","abandon","art"},
+    ByteData("bda85446c68413707090a52022edd26a1c9462295029f2e60cd7c4f2bbd3097170af7a4d73245cafa9c3cca8d561a7c3de6f5d4a10be8ed2a5e608d68f92fcc8")
+  },
+  {
+    ByteData("7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f"),
+    {"legal","winner","thank","year","wave","sausage","worth","useful","legal","winner","thank","year","wave","sausage","worth","useful","legal","winner","thank","year","wave","sausage","worth","title"},
+    ByteData("bc09fca1804f7e69da93c2f2028eb238c227f2e9dda30cd63699232578480a4021b146ad717fbb7e451ce9eb835f43620bf5c514db0f8add49f5d121449d3e87")
+  },
+  {
+    ByteData("8080808080808080808080808080808080808080808080808080808080808080"),
+    {"letter","advice","cage","absurd","amount","doctor","acoustic","avoid","letter","advice","cage","absurd","amount","doctor","acoustic","avoid","letter","advice","cage","absurd","amount","doctor","acoustic","bless"},
+    ByteData("c0c519bd0e91a2ed54357d9d1ebef6f5af218a153624cf4f2da911a0ed8f7a09e2ef61af0aca007096df430022f7a2b6fb91661a9589097069720d015e4e982f")
+  },
+  {
+    ByteData("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+    {"zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","zoo","vote"},
+    ByteData("dd48c104698c30cfe2b6142103248622fb7bb0ff692eebb00089b32d22484e1613912f0a5b694407be899ffd31ed3992c456cdf60f5d4564b8ba3f05a69890ad")
+  },
+  {
+    ByteData("9e885d952ad362caeb4efe34a8e91bd2"),
+    {"ozone","drill","grab","fiber","curtain","grace","pudding","thank","cruise","elder","eight","picnic"},
+    ByteData("274ddc525802f7c828d8ef7ddbcdc5304e87ac3535913611fbbfa986d0c9e5476c91689f9c8a54fd55bd38606aa6a8595ad213d4c9c9f9aca3fb217069a41028")
+  },
+  {
+    ByteData("6610b25967cdcca9d59875f5cb50b0ea75433311869e930b"),
+    {"gravity","machine","north","sort","system","female","filter","attitude","volume","fold","club","stay","feature","office","ecology","stable","narrow","fog"},
+    ByteData("628c3827a8823298ee685db84f55caa34b5cc195a778e52d45f59bcf75aba68e4d7590e101dc414bc1bbd5737666fbbef35d1f1903953b66624f910feef245ac")
+  },
+  {
+    ByteData("68a79eaca2324873eacc50cb9c6eca8cc68ea5d936f98787c60c7ebc74e6ce7c"),
+    {"hamster","diagram","private","dutch","cause","delay","private","meat","slide","toddler","razor","book","happy","fancy","gospel","tennis","maple","dilemma","loan","word","shrug","inflict","delay","length"},
+    ByteData("64c87cde7e12ecf6704ab95bb1408bef047c22db4cc7491c4271d170a1b213d20b385bc1588d9c7b38f1b39d415665b8a9030c9ec653d75e65f847d8fc1fc440")
+  },
+  {
+    ByteData("c0ba5a8e914111210f2bd131f3d5e08d"),
+    {"scheme","spot","photo","card","baby","mountain","device","kick","cradle","pact","join","borrow"},
+    ByteData("ea725895aaae8d4c1cf682c1bfd2d358d52ed9f0f0591131b559e2724bb234fca05aa9c02c57407e04ee9dc3b454aa63fbff483a8b11de949624b9f1831a9612")
+  },
+  {
+    ByteData("6d9be1ee6ebd27a258115aad99b7317b9c8d28b6d76431c3"),
+    {"horn","tenant","knee","talent","sponsor","spell","gate","clip","pulse","soap","slush","warm","silver","nephew","swap","uncle","crack","brave"},
+    ByteData("fd579828af3da1d32544ce4db5c73d53fc8acc4ddb1e3b251a31179cdb71e853c56d2fcb11aed39898ce6c34b10b5382772db8796e52837b54468aeb312cfc3d")
+  },
+  {
+    ByteData("9f6a2878b2520799a44ef18bc7df394e7061a224d2c33cd015b157d746869863"),
+    {"panda","eyebrow","bullet","gorilla","call","smoke","muffin","taste","mesh","discover","soft","ostrich","alcohol","speed","nation","flash","devote","level","hobby","quick","inner","drive","ghost","inside"},
+    ByteData("72be8e052fc4919d2adf28d5306b5474b0069df35b02303de8c1729c9538dbb6fc2d731d5f832193cd9fb6aeecbc469594a70e3dd50811b5067f3b88b28c3e8d")
+  },
+  {
+    ByteData("23db8160a31d3e0dca3688ed941adbf3"),
+    {"cat","swing","flag","economy","stadium","alone","churn","speed","unique","patch","report","train"},
+    ByteData("deb5f45449e615feff5640f2e49f933ff51895de3b4381832b3139941c57b59205a42480c52175b6efcffaa58a2503887c1e8b363a707256bdd2b587b46541f5")
+  },
+  {
+    ByteData("8197a4a47f0425faeaa69deebc05ca29c0a5b5cc76ceacc0"),
+    {"light","rule","cinnamon","wrap","drastic","word","pride","squirrel","upgrade","then","income","fatal","apart","sustain","crack","supply","proud","access"},
+    ByteData("4cbdff1ca2db800fd61cae72a57475fdc6bab03e441fd63f96dabd1f183ef5b782925f00105f318309a7e9c3ea6967c7801e46c8a58082674c860a37b93eda02")
+  },
+  {
+    ByteData("066dca1a2bb7e8a1db2832148ce9933eea0f3ac9548d793112d9a95c9407efad"),
+    {"all","hour","make","first","leader","extend","hole","alien","behind","guard","gospel","lava","path","output","census","museum","junior","mass","reopen","famous","sing","advance","salt","reform"},
+    ByteData("26e975ec644423f4a4c4f4215ef09b4bd7ef924e85d1d17c4cf3f136c2863cf6df0a475045652c57eb5fb41513ca2a2d67722b77e954b4b3fc11f7590449191d")
+  },
+  {
+    ByteData("f30f8c1da665478f49b001d94c5fc452"),
+    {"vessel","ladder","alter","error","federal","sibling","chat","ability","sun","glass","valve","picture"},
+    ByteData("2aaa9242daafcee6aa9d7269f17d4efe271e1b9a529178d7dc139cd18747090bf9d60295d0ce74309a78852a9caadf0af48aae1c6253839624076224374bc63f")
+  },
+  {
+    ByteData("c10ec20dc3cd9f652c7fac2f1230f7a3c828389a14392f05"),
+    {"scissors","invite","lock","maple","supreme","raw","rapid","void","congress","muscle","digital","elegant","little","brisk","hair","mango","congress","clump"},
+    ByteData("7b4a10be9d98e6cba265566db7f136718e1398c71cb581e1b2f464cac1ceedf4f3e274dc270003c670ad8d02c4558b2f8e39edea2775c9e232c7cb798b069e88")
+  },
+  {
+    ByteData("f585c11aec520db57dd353c69554b21a89b20fb0650966fa0a9d6f74fd989d8f"),
+    {"void","come","effort","suffer","camp","survey","warrior","heavy","shoot","primary","clutch","crush","open","amazing","screen","patrol","group","space","point","ten","exist","slush","involve","unfold"},
+    ByteData("01f5bced59dec48e362f2c45b5de68b9fd6c92c6634f44d6d40aab69056506f0e35524a518034ddc1192e1dacd32c1ed3eaa3c3b131c88ed8e7e54c49a5d0998")
+  }
+};
+
+TEST(HDWallet, ConvertTest) {
+  ByteData actual_entropy;
+  std::vector<std::string> actual_mnemonic;
+  ByteData actual_seed;
+  bool actual_is_valid;
+  for (Bip39TestVector test_vector : bip39_test_vectors) {
+    EXPECT_NO_THROW(actual_entropy = HDWallet::ConvertMnemonicToEntropy(test_vector.mnemonic, language));
+    EXPECT_NO_THROW(actual_mnemonic = HDWallet::ConvertEntropyToMnemonic(test_vector.entropy, language));
+    EXPECT_NO_THROW(actual_seed = HDWallet::ConvertMnemonicToSeed(test_vector.mnemonic, test_passphrase));
+    EXPECT_NO_THROW(actual_is_valid = HDWallet::CheckValidMnemonic(test_vector.mnemonic, language));
+    EXPECT_TRUE(actual_entropy.Equals(test_vector.entropy));
+    EXPECT_EQ(actual_mnemonic, test_vector.mnemonic);
+    EXPECT_TRUE(actual_seed.Equals(test_vector.seed));
+    EXPECT_TRUE(actual_is_valid);
+  }
+}
+
+const std::vector<std::string> empty_mnemonic = {};
+const std::vector<std::string> invalid_words_mnemonic = {"aa","aa","aa","aa","aa","aa","aa","aa","aa","aa","aa","abort"};
+
+TEST(HDWallet, ConvertMnemonicToSeedAllowAnyTest) {
+  try {
+    ByteData actual_seed;
+    // check empty mnemonic
+    EXPECT_NO_THROW(actual_seed = HDWallet::ConvertMnemonicToSeed(empty_mnemonic, test_passphrase));
+
+    // check invalid mnemonic
+    EXPECT_NO_THROW(actual_seed = HDWallet::ConvertMnemonicToSeed(invalid_words_mnemonic, test_passphrase));
+  } catch (...) {
+    // force to fail test
+    EXPECT_TRUE(false);
+  }
+}
+
+TEST(HDWallet, ConvertEntropyToMnemonicErrorTest) {
+  std::vector<std::string> actual_mnemonic;
+  try {
+    ByteData empty_entropy("");
+    // check empty mnemonic
+    EXPECT_THROW(actual_mnemonic = HDWallet::ConvertEntropyToMnemonic(empty_entropy, language), CfdException);
+
+    // check invalid mnemonic
+    ByteData invalid_length_entropy("000000000000000000000000000000");
+    EXPECT_THROW(actual_mnemonic = HDWallet::ConvertEntropyToMnemonic(invalid_length_entropy, language), CfdException);
+  } catch (CfdException &e) {
+    EXPECT_STREQ(e.what(), "Convert entropy to mnemonic error.");
+  } catch (...) {
+    // force to fail test
+    EXPECT_TRUE(false);
+  }
+
+  try {
+    ByteData entropy = bip39_test_vectors[0].entropy;
+    EXPECT_THROW(actual_mnemonic = HDWallet::ConvertEntropyToMnemonic(entropy, "zz"), CfdException);
+  } catch (CfdException &e) {
+    EXPECT_STREQ(e.what(), "Not support language passed.");
+  } catch (...) {
+    // force to fail test
+    EXPECT_TRUE(false);
+  }
+}
+
+TEST(HDWallet, ConvertMnemonicToEntropyErrorTest) {
+  ByteData actual_entropy;
+  try {
+    // check empty mnemonic
+    EXPECT_THROW(actual_entropy = HDWallet::ConvertMnemonicToEntropy(empty_mnemonic, language), CfdException);
+
+    // check invalid mnemonic
+    EXPECT_THROW(actual_entropy = HDWallet::ConvertMnemonicToEntropy(invalid_words_mnemonic, language), CfdException);
+  } catch (CfdException &e) {
+    EXPECT_STREQ(e.what(), "Convert mnemonic to entropy error.");
+  } catch (...) {
+    // force to fail test
+    EXPECT_TRUE(false);
+  }
+
+  try {
+    std::vector<std::string> mnemonic = bip39_test_vectors[0].mnemonic;
+    EXPECT_THROW(actual_entropy = HDWallet::ConvertMnemonicToEntropy(mnemonic, "zz"), CfdException);
+  } catch (CfdException &e) {
+    EXPECT_STREQ(e.what(), "Not support language passed.");
+  } catch (...) {
+    // force to fail test
+    EXPECT_TRUE(false);
+  }
+}
+
+TEST(HDWallet, CheckInvalidMnemonicTest) {
+  // check empty mnemonic
+  EXPECT_FALSE(HDWallet::CheckValidMnemonic(empty_mnemonic, language));
+
+  // check invalid mnemonic
+  EXPECT_FALSE(HDWallet::CheckValidMnemonic(invalid_words_mnemonic, language));
+
+  // check use_ideographic space separator mnemonic
+  EXPECT_FALSE(HDWallet::CheckValidMnemonic(bip39_test_vectors[0].mnemonic, language, true));
+
+  try {
+    EXPECT_THROW(HDWallet::CheckValidMnemonic(bip39_test_vectors[0].mnemonic, "zz"), CfdException);
   } catch (CfdException &e) {
     EXPECT_STREQ(e.what(), "Not support language passed.");
   } catch (...) {

--- a/test/test_stringutil.cpp
+++ b/test/test_stringutil.cpp
@@ -72,63 +72,74 @@ TEST(StringUtil, ByteToStringEmpty) {
   EXPECT_STREQ(result.c_str(), "");
 }
 
-TEST(StringUtil, SplitTest) {
+TEST(StringUtil, SplitAndJoinTest) {
   std::vector<std::string> expect_vec = {
     "The", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog"
   };
-  std::map<std::string, char> test_vector = {
+  std::map<std::string, std::string> test_vector = {
     {
       "The quick brown fox jumps over the lazy dog",
-      ' '
+      " "
     },
     {
       "The_quick_brown_fox_jumps_over_the_lazy_dog",
-      '_'
+      "_"
     },
     {
       "The%quick%brown%fox%jumps%over%the%lazy%dog",
-      '%'
+      "%"
     },
     {
-      "The%quick%brown%fox%jumps%over%the%lazy%dog%",
-      '%'
+      "The=>quick=>brown=>fox=>jumps=>over=>the=>lazy=>dog",
+      "=>"
     }
   };
 
-  std::vector<std::string> actual;
+  std::vector<std::string> actual_split_word;
+  std::string actual_join_str;
   for (auto vec : test_vector) {
-    EXPECT_NO_THROW(actual = StringUtil::Split(vec.first, vec.second));
-    EXPECT_EQ(actual, expect_vec);
+    EXPECT_NO_THROW(actual_split_word = StringUtil::Split(vec.first, vec.second));
+    EXPECT_EQ(actual_split_word, expect_vec);
+    EXPECT_NO_THROW(actual_join_str = StringUtil::Join(actual_split_word, vec.second));
+    EXPECT_STREQ(actual_join_str.c_str(), vec.first.c_str());
   }
 }
 
-TEST(StringUtil, SplitEmptyStringTest) {
+TEST(StringUtil, SplitAndJoinEmptyStringTest) {
   struct TestVector {
     std::string str;
-    char delimiter;
+    std::string delimiter;
     std::vector<std::string> expect;
   };
   std::vector<TestVector> test_vector = {
     {
       " ",
-      '*',
+      "*",
       {" "}
     },
     {
       "**",
-      '*',
+      "**",
       {"", ""}
     },
     {
+      "**",
+      "*",
+      {"", "", ""}
+    },
+    {
       "",
-      '*',
-      {}
+      "*",
+      {""}
     }
   };
 
-  std::vector<std::string> actual;
+  std::vector<std::string> actual_split_word;
+  std::string actual_join_str;
   for (auto vec : test_vector) {
-    EXPECT_NO_THROW(actual = StringUtil::Split(vec.str, vec.delimiter));
-    EXPECT_EQ(actual, vec.expect);
+    EXPECT_NO_THROW(actual_split_word = StringUtil::Split(vec.str, vec.delimiter));
+    EXPECT_EQ(actual_split_word, vec.expect);
+    EXPECT_NO_THROW(actual_join_str = StringUtil::Join(actual_split_word, vec.delimiter));
+    EXPECT_STREQ(actual_join_str.c_str(), vec.str.c_str());
   }
 }


### PR DESCRIPTION
## 関連Issue

<!--
このPRが、ZenHubのどのIssueに紐づいているかを記載する
  - ZenHubのURL
-->

- [#782](https://app.zenhub.com/workspaces/cfd-5cdbe88f0f84751dcd8fd7ab/issues/cryptogarageinc/btclib-sandbox/782)

## 概要

<!--
- 追加機能の概要を記載
- 前提が共有されていない場合は、  
  なぜこの変更をして、  
  どう解決されるのかも併せて記載する

- 必要であれば、以下のような詳細についても記載する
  - 以下の観点で、レビューアーにわかるように技術的な変更点の概要を記載
    - 何をどう変更したか
    - どういった手法を採用したか  
      （e.g. パス探索については、幅優先探索を採用した）
    - 外部システムとのI/F変更
    - など
-->

- mnemonic変換関数を追加
  - ConvertMnemonicToSeed: mnemonic -> seed
  - ConvertMnemonicToEntropy: mnemonic -> entropy
  - ConvertEntropyToMnemonic: entropy -> mnemonic
- mnemonic検証関数を追加
  - CheckValidMnemonic: mnemonicが正しいwordで構成されているかを検証する
- languageのvalidation責務をHdWalletクラスへ移譲

## 使い方

<!-- 
- PRの動作確認方法
  - 動作確認が必要なタスクについては、必要なコマンドなどを記載
  - 必要なければ、無記載で良い
-->

```bash
npm run cmake_all && npm run ctest
```

## 今回保留した項目とTODO

<!--
- 箇条書きで保留した項目があれば、記載
  - 保留項目が直近の対応が必要な場合、対応チケットを作成して記載

記載例
- 〇〇の計算ロジックの本実装 #0000
-->

- 

## 確認項目

**PRを出した人**
<!-- PRを出す前後で確認する項目 -->

- [x] チェックスクリプトでチェックを実施した <!-- npm run check -->
- [x] 正常にビルドできた
- [x] 関連チケットに実績をつけた
- [x] ZenHubでPRとIssueを関連付けた
- [x] ZenHubのIssueを `Review/QA` Pipelineに移した

**レビューする人**
<!-- レビューをする前後で確認する項目 -->
- [x] 関連チケットにレビュー実績をつけた

## 備考

<!--
- 実装に関する悩み（AにするかBにするか迷ったがAにしたや、こうしたかったけどできなかったなど）があれば記載
-->

- string <-> vector<string>の責務を `HdWallet`にするかどうか迷ったがGetMnemonicWordlist関数を考えると、words構造体をWallyUtil以外の層に出したくなかったため、 `WallyUtil`に押し込めた