### PR TITLE
elements無効時のテスト不具合修正

### DIFF
--- a/test/test_abstract_transaction.cpp
+++ b/test/test_abstract_transaction.cpp
@@ -301,10 +301,10 @@ TEST(AbstractTransaction, CopyVariableBuffer) {
 }
 
 TEST(AbstractTransaction, TxSizeByException) {
-  TestTransaction tx;
-  EXPECT_THROW(tx.GetTotalSize(), CfdException);
-  EXPECT_THROW(tx.GetVsize(), CfdException);
-  EXPECT_THROW(tx.GetWeight(), CfdException);
+  Transaction tx;
+  EXPECT_EQ(tx.GetTotalSize(), 10);
+  EXPECT_EQ(tx.GetVsize(), 10);
+  EXPECT_EQ(tx.GetWeight(), 40);
 }
 
 TEST(AbstractTransaction, TxArray) {

--- a/test/test_abstract_transaction.cpp
+++ b/test/test_abstract_transaction.cpp
@@ -1,6 +1,8 @@
 #include "gtest/gtest.h"
 #include <vector>
 
+#include "wally_core.h"
+#include "wally_transaction.h"
 #include "cfdcore/cfdcore_common.h"
 #include "cfdcore/cfdcore_exception.h"
 #include "cfdcore/cfdcore_util.h"
@@ -16,13 +18,20 @@ using cfd::core::TxOutReference;
 using cfd::core::ByteData;
 using cfd::core::Amount;
 using cfd::core::CfdException;
+using cfd::core::CfdError;
 using cfd::core::ByteData256;
 using cfd::core::StringUtil;
 
 class TestTransaction : public AbstractTransaction {
  public:
   TestTransaction() {
-    // do nothing
+    struct wally_tx *tx_pointer = NULL;
+    int ret = wally_tx_init_alloc(2, 0, 0, 0, &tx_pointer);
+    if (ret != WALLY_OK) {
+      throw CfdException(
+          CfdError::kCfdIllegalArgumentError, "transaction data generate error.");
+    }
+    wally_tx_pointer_ = tx_pointer;
   }
   virtual ~TestTransaction() {
     // do nothing
@@ -301,7 +310,7 @@ TEST(AbstractTransaction, CopyVariableBuffer) {
 }
 
 TEST(AbstractTransaction, TxSizeByException) {
-  Transaction tx;
+  TestTransaction tx;
   EXPECT_EQ(tx.GetTotalSize(), 10);
   EXPECT_EQ(tx.GetVsize(), 10);
   EXPECT_EQ(tx.GetWeight(), 40);

--- a/test/test_address.cpp
+++ b/test/test_address.cpp
@@ -563,7 +563,11 @@ TEST(Address, ElementsNoSegwitAddressFromStringTest) {
   EXPECT_NO_THROW((address = Address("2dnmekh8NBmNX3Ckwte5CArjcsHLYdthCg3", params)));
   EXPECT_STREQ("2dnmekh8NBmNX3Ckwte5CArjcsHLYdthCg3",
                address.GetAddress().c_str());
+#ifndef CFD_DISABLE_ELEMENTS
   EXPECT_EQ(NetType::kElementsRegtest, address.GetNetType());
+#else
+  EXPECT_EQ(NetType::kNetTypeNum, address.GetNetType());
+#endif  // CFD_DISABLE_ELEMENTS
   EXPECT_EQ(AddressType::kP2pkhAddress, address.GetAddressType());
   EXPECT_EQ(WitnessVersion::kVersionNone, address.GetWitnessVersion());
   EXPECT_STREQ("925d4028880bd0c9d68fbc7fc7dfee976698629c",
@@ -574,7 +578,11 @@ TEST(Address, ElementsNoSegwitAddressFromStringTest) {
   EXPECT_NO_THROW((address = Address("XUiq7kxdkiB3AXNkKW9YaWLLGb1WBo9xcA", params)));
   EXPECT_STREQ("XUiq7kxdkiB3AXNkKW9YaWLLGb1WBo9xcA",
                address.GetAddress().c_str());
+#ifndef CFD_DISABLE_ELEMENTS
   EXPECT_EQ(NetType::kElementsRegtest, address.GetNetType());
+#else
+  EXPECT_EQ(NetType::kNetTypeNum, address.GetNetType());
+#endif  // CFD_DISABLE_ELEMENTS
   EXPECT_EQ(AddressType::kP2shAddress, address.GetAddressType());
 
   // analyze fail data
@@ -591,7 +599,11 @@ TEST(Address, ElementsSegwitAddressFromStringTest) {
   EXPECT_NO_THROW((address = Address("ert1qjfw5q2ygp0gvn450h3lu0hlwjanfsc5udafvh6", params)));
   EXPECT_STREQ("ert1qjfw5q2ygp0gvn450h3lu0hlwjanfsc5udafvh6",
                address.GetAddress().c_str());
+#ifndef CFD_DISABLE_ELEMENTS
   EXPECT_EQ(NetType::kElementsRegtest, address.GetNetType());
+#else
+  EXPECT_EQ(NetType::kNetTypeNum, address.GetNetType());
+#endif  // CFD_DISABLE_ELEMENTS
   EXPECT_EQ(AddressType::kP2wpkhAddress, address.GetAddressType());
   EXPECT_EQ(WitnessVersion::kVersion0, address.GetWitnessVersion());
   EXPECT_STREQ("925d4028880bd0c9d68fbc7fc7dfee976698629c",
@@ -602,7 +614,11 @@ TEST(Address, ElementsSegwitAddressFromStringTest) {
   EXPECT_NO_THROW((address = Address("ert1qcc5c9wnzly8zj2dcsvxv83kupsu0uamx69u0y9lsmw7shuns2gqsflana4", params)));
   EXPECT_STREQ("ert1qcc5c9wnzly8zj2dcsvxv83kupsu0uamx69u0y9lsmw7shuns2gqsflana4",
                address.GetAddress().c_str());
+#ifndef CFD_DISABLE_ELEMENTS
   EXPECT_EQ(NetType::kElementsRegtest, address.GetNetType());
+#else
+  EXPECT_EQ(NetType::kNetTypeNum, address.GetNetType());
+#endif  // CFD_DISABLE_ELEMENTS
   EXPECT_EQ(AddressType::kP2wshAddress, address.GetAddressType());
   EXPECT_EQ(WitnessVersion::kVersion0, address.GetWitnessVersion());
 }


### PR DESCRIPTION
## 関連Issue

<!--
このPRが、ZenHubのどのIssueに紐づいているかを記載する
  - ZenHubのURL
-->
- https://app.zenhub.com/workspaces/cfd-5cdbe88f0f84751dcd8fd7ab/issues/cryptogarageinc/btclib-sandbox/823

## 概要

<!--
- 追加機能の概要を記載
- 前提が共有されていない場合は、  
  なぜこの変更をして、  
  どう解決されるのかも併せて記載する

- 必要であれば、以下のような詳細についても記載する
  - 以下の観点で、レビューアーにわかるように技術的な変更点の概要を記載
    - 何をどう変更したか
    - どういった手法を採用したか  
      （e.g. パス探索については、幅優先探索を採用した）
    - 外部システムとのI/F変更
    - など
-->

- cfd-core
  - elements無効ビルド時のテスト不具合修正
    - AbstractTransactionのサイズ取得時、libwallyに空のポインタが渡されていた。
      - テスト用クラスのコンストラクタで空のTransactionを作成してポインタ設定するよう修正。
      - Transactionクラスを使おうと思ったが、Transactionクラスは該当関数をオーバーライドしていたのでabstractの関数は使っていなかった。
    - AddressクラスでElements用のテスト実施時に返却されていたパラメータがカスタム値となっていた。
      - 該当APIの仕様上、Inputに対す居る結果は正しいため、IFDEFでテスト結果判定を切り替えるよう修正。
- cfd-js
  - elements無効ビルド時のビルド不具合修正
    - elementsとbtc共通のAPIで、Elements参照時にクラスが参照できずエラーとなっていた。
    - elements無効時は関数にbtcの関数を設定するよう修正。

## 使い方

<!-- 
- PRの動作確認方法
  - 動作確認が必要なタスクについては、必要なコマンドなどを記載
  - 必要なければ、無記載で良い
-->

```bash
npm run cmake_elem_off
npm run test_all
```

## 今回保留した項目とTODO

<!--
- 箇条書きで保留した項目があれば、記載
  - 保留項目が直近の対応が必要な場合、対応チケットを作成して記載

記載例
- 〇〇の計算ロジックの本実装 #0000
-->

- btc無効ビルドについては今回すっ飛ばした。。
  - 今後もbtc無効ビルドは、オフにした方がいいかも。

## 確認項目

**PRを出した人**
<!-- PRを出す前後で確認する項目 -->

- [ ] チェックスクリプトでチェックを実施した <!-- npm run check -->
- [x] 正常にビルドできた
- [x] 関連チケットに実績をつけた
- [x] ZenHubでPRとIssueを関連付けた
- [x] ZenHubのIssueを `Review/QA` Pipelineに移した

**レビューする人**
<!-- レビューをする前後で確認する項目 -->
- [ ] 関連チケットにレビュー実績をつけた

## 備考

<!--
- 実装に関する悩み（AにするかBにするか迷ったがAにしたや、こうしたかったけどできなかったなど）があれば記載
-->
