### PR TITLE
Feature/cpplint 20191018

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,9 +1,24 @@
 project(external_download NONE)
 
+# load file
+set(EXTERNAL_DEBUG_FILENAME  external_project_debug.config)
+set(DEBUG_VERSION_FILE  ${CMAKE_SOURCE_DIR}/${EXTERNAL_DEBUG_FILENAME})
+if(EXISTS ${DEBUG_VERSION_FILE})
+transform_makefile_srclist(${DEBUG_VERSION_FILE} "${CMAKE_CURRENT_BINARY_DIR}/${EXTERNAL_DEBUG_FILENAME}.cmake")
+include(${CMAKE_CURRENT_BINARY_DIR}/${EXTERNAL_DEBUG_FILENAME}.cmake)
+endif()
+
 # libwally-core
+if(LIBWALLY_TARGET_VERSION)
+set(LIBWALLY_TARGET_TAG  ${LIBWALLY_TARGET_VERSION})
+message(STATUS "[external project debug] libwally-core target=${LIBWALLY_TARGET_VERSION}")
+else()
+set(LIBWALLY_TARGET_TAG  cmake_build)
+endif()
+
 set(TEMPLATE_PROJECT_NAME           libwally-core)
 set(TEMPLATE_PROJECT_GIT_REPOSITORY https://github.com/cryptogarageinc/libwally-core.git)
-set(TEMPLATE_PROJECT_GIT_TAG        cmake_build)
+set(TEMPLATE_PROJECT_GIT_TAG        ${LIBWALLY_TARGET_TAG})
 set(PROJECT_EXTERNAL  "${CMAKE_SOURCE_DIR}/external/${TEMPLATE_PROJECT_NAME}/external")
 set(DIR_PATH "${CFD_ROOT_BINARY_DIR}/${TEMPLATE_PROJECT_NAME}")
 set(DL_PATH "${CFD_ROOT_BINARY_DIR}/external/${TEMPLATE_PROJECT_NAME}/download")
@@ -39,9 +54,16 @@ endif()
 
 
 # googletest
+if(GTEST_TARGET_VERSION)
+set(GTEST_TARGET_TAG  ${GTEST_TARGET_VERSION})
+message(STATUS "[external project debug] google-test target=${GTEST_TARGET_VERSION}")
+else()
+set(GTEST_TARGET_TAG  release-1.8.1)
+endif()
+
 set(TEMPLATE_PROJECT_NAME           googletest)
 set(TEMPLATE_PROJECT_GIT_REPOSITORY https://github.com/google/googletest.git)
-set(TEMPLATE_PROJECT_GIT_TAG        release-1.8.1)
+set(TEMPLATE_PROJECT_GIT_TAG        ${GTEST_TARGET_TAG})
 set(PROJECT_EXTERNAL  "${CMAKE_SOURCE_DIR}/external/${TEMPLATE_PROJECT_NAME}/external")
 set(DL_PATH "${CFD_ROOT_BINARY_DIR}/external/${TEMPLATE_PROJECT_NAME}/download")
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "lint_check:darwin": "cd tools && ./lint_quiet.sh",
     "git_subm_update": "git submodule -q foreach git fetch -q && git submodule -q update -i",
     "check": "run-s lint_check doxygen_check ctest_quiet",
-    "check_all": "run-s cmake_clean git_subm_update lint_check doxygen_check cmake_quiet ctest_quiet"
+    "check_all": "run-s cmake_clean git_subm_update lint_check cmake_quiet doxygen_check ctest_quiet"
   },
   "author": "",
   "license": "MIT",

--- a/tools/cpplint/cpplint.py
+++ b/tools/cpplint/cpplint.py
@@ -1140,7 +1140,8 @@ class FileInfo(object):
           one_up_dir = os.path.dirname(one_up_dir)
 
         prefix = os.path.commonprefix([root_dir, project_dir])
-        return fullname[len(prefix) + 1:]
+        sep_len = 0 if(prefix[-1:] == "/") else 1
+        return fullname[len(prefix) + sep_len:]
 
       # Not SVN <= 1.6? Try to find a git, hg, or svn top level directory by
       # searching up from the current path.
@@ -1156,9 +1157,14 @@ class FileInfo(object):
           os.path.exists(os.path.join(root_dir, ".hg")) or
           os.path.exists(os.path.join(root_dir, ".svn"))):
         prefix = os.path.commonprefix([root_dir + '/external', project_dir])
+        prefix2 = os.path.commonprefix([root_dir, project_dir])
         # sys.stderr.write('[%s]\n' % (prefix))
         # prefix = os.path.commonprefix([root_dir, project_dir])
-        return fullname[len(prefix) + 1:]
+        if(prefix[-1:] == "/"):   prefix = prefix[:-1]
+        if(prefix2[-1:] == "/"):  prefix2 = prefix2[:-1]
+        if (prefix == prefix2):   prefix = '/'.join(prefix2.split('/')[0:-1])
+        sep_len = 0 if(prefix[-1:] == "/") else 1
+        return fullname[len(prefix) + sep_len:]
 
     # Don't know what to do; header guard warnings may be wrong...
     return fullname


### PR DESCRIPTION
## 関連Issue

<!--
このPRが、ZenHubのどのIssueに紐づいているかを記載する
  - ZenHubのURL
-->

## 概要

<!--
- 追加機能の概要を記載
- 前提が共有されていない場合は、  
  なぜこの変更をして、  
  どう解決されるのかも併せて記載する

- 必要であれば、以下のような詳細についても記載する
  - 以下の観点で、レビューアーにわかるように技術的な変更点の概要を記載
    - 何をどう変更したか
    - どういった手法を採用したか  
      （e.g. パス探索については、幅優先探索を採用した）
    - 外部システムとのI/F変更
    - など
-->

- cpplint.pyの不具合修正
  - 仕様不一致
    - googleのprojectはgitレポジトリの配下にプロジェクトを設置するが、cfdはgitレポジトリ自体をプロジェクトとしていた。
    - cfdではgitレポジトリ自体をプロジェクトフォルダとするよう修正
  - 既存不具合
    - パスの一致範囲チェック時、パス区切りの有無に限らずパス区切りありを想定して "+1" していた。
    - パス区切りがチェック時文字列の終端にある場合、削除してから処理するよう修正。
- external projectのcheckout version(tag or branch)デバッグ機能対応
  - 外部設定ファイル存在時、ファイルを読み込み、かつ対応する設定値が存在した場合に、指定されたタグorブランチ名をチェックアウトする。
  - ルートとなるプロジェクトの直下に対象ファイルを置いた場合のみ有効となる。
  - 対象がlibwallyとgoogletestのみであるため、確認は除外。

## 使い方

<!-- 
- PRの動作確認方法
  - 動作確認が必要なタスクについては、必要なコマンドなどを記載
  - 必要なければ、無記載で良い
-->

```bash
tools/lint.sh
```

## 今回保留した項目とTODO

<!--
- 箇条書きで保留した項目があれば、記載
  - 保留項目が直近の対応が必要な場合、対応チケットを作成して記載

記載例
- 〇〇の計算ロジックの本実装 #0000
-->

- URLの変更可否については迷ったが、今回は無しにした。仕組み上、同様の方法で対応可能。

## 確認項目

**PRを出した人**
<!-- PRを出す前後で確認する項目 -->

- [x] チェックスクリプトでチェックを実施した <!-- npm run check -->
- [ ] 正常にビルドできた
- [ ] 関連チケットに実績をつけた
- [ ] ZenHubでPRとIssueを関連付けた
- [ ] ZenHubのIssueを `Review/QA` Pipelineに移した

**レビューする人**
<!-- レビューをする前後で確認する項目 -->
- [ ] 関連チケットにレビュー実績をつけた

## 備考

<!--
- 実装に関する悩み（AにするかBにするか迷ったがAにしたや、こうしたかったけどできなかったなど）があれば記載
-->
